### PR TITLE
wiki: add --label filter to search, fix silent CQL parse failure

### DIFF
--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -922,6 +922,7 @@ class TestSearchCommand:
             space=None,
             cql=None,
             creator=None,
+            label=None,
             limit=25,
             format="default",
         )
@@ -951,6 +952,7 @@ class TestSearchCommand:
             space=None,
             cql=None,
             creator=None,
+            label=None,
             limit=25,
             format="json",
         )
@@ -979,6 +981,7 @@ class TestSearchCommand:
             space=None,
             cql=None,
             creator=None,
+            label=None,
             limit=25,
             format="url",
         )
@@ -1010,6 +1013,7 @@ class TestSearchCommand:
             space=None,
             cql=None,
             creator=None,
+            label=None,
             limit=25,
             format="id",
         )
@@ -1038,6 +1042,7 @@ class TestSearchCommand:
             space=None,
             cql=None,
             creator=None,
+            label=None,
             limit=25,
             format="default",
         )
@@ -1068,6 +1073,7 @@ class TestSearchCommand:
             space=None,
             cql=None,
             creator=None,
+            label=None,
             limit=25,
             format="default",
         )
@@ -1100,6 +1106,7 @@ class TestSearchCommand:
             space="MYSPACE",
             cql=None,
             creator=None,
+            label=None,
             limit=25,
             format="default",
         )
@@ -1133,6 +1140,7 @@ class TestSearchCommand:
             cql=None,
             space=None,
             creator="John Doe",
+            label=None,
             limit=25,
             format="default",
         )
@@ -1144,6 +1152,82 @@ class TestSearchCommand:
             search_command(args)
 
         assert 'creator.fullname ~ "John Doe"' in cql_received[0]
+
+    def test_search_with_label_filter(self, mock_confluence, capsys):
+        """Filters by label, with the value quoted.
+
+        Confluence's CQL parser silently fails ("could not parse cql") on
+        hyphenated label values passed unquoted, e.g. label=aws-services —
+        the value must always be quoted.
+        """
+        from zaira.wiki import search_command
+        from zaira import confluence_api
+        import argparse
+
+        cql_received = []
+
+        def mock_search(cql, limit, expand):
+            cql_received.append(cql)
+            return {
+                "results": [{"id": "12345", "title": "Page", "space": {"key": "TEST"}}]
+            }
+
+        confluence_api.set_api("search_pages", mock_search)
+
+        args = argparse.Namespace(
+            query="test",
+            cql=None,
+            space=None,
+            creator=None,
+            label="aws-services",
+            limit=25,
+            format="default",
+        )
+
+        with patch(
+            "zaira.wiki.get_server_from_config",
+            return_value="https://site.atlassian.net",
+        ):
+            search_command(args)
+
+        assert 'label = "aws-services"' in cql_received[0]
+
+    def test_search_with_space_and_label_filter(self, mock_confluence, capsys):
+        """Combines space and label filters with AND, both quoted."""
+        from zaira.wiki import search_command
+        from zaira import confluence_api
+        import argparse
+
+        cql_received = []
+
+        def mock_search(cql, limit, expand):
+            cql_received.append(cql)
+            return {
+                "results": [{"id": "12345", "title": "Page", "space": {"key": "BTA"}}]
+            }
+
+        confluence_api.set_api("search_pages", mock_search)
+
+        args = argparse.Namespace(
+            query="Proton",
+            cql=None,
+            space="BTA",
+            creator=None,
+            label="aws-services",
+            limit=25,
+            format="default",
+        )
+
+        with patch(
+            "zaira.wiki.get_server_from_config",
+            return_value="https://site.atlassian.net",
+        ):
+            search_command(args)
+
+        cql = cql_received[0]
+        assert 'space = "BTA"' in cql
+        assert 'label = "aws-services"' in cql
+        assert " AND " in cql
 
 
 class TestGetCommand:

--- a/zaira/cli.py
+++ b/zaira/cli.py
@@ -995,6 +995,10 @@ def main() -> None:
         help="Filter by page creator name",
     )
     wiki_search.add_argument(
+        "--label",
+        help="Filter by page label",
+    )
+    wiki_search.add_argument(
         "--limit",
         type=int,
         default=25,

--- a/zaira/wiki.py
+++ b/zaira/wiki.py
@@ -509,6 +509,12 @@ def search_command(args: argparse.Namespace) -> None:
         if args.creator:
             cql_parts.append(f'creator.fullname ~ "{args.creator}"')
 
+        # Optional label filter — the value must be quoted or Confluence's
+        # CQL parser fails silently on hyphenated label names (e.g.
+        # "aws-services" without quotes returns a "could not parse cql" error)
+        if args.label:
+            cql_parts.append(f'label = "{args.label}"')
+
         # Only search pages (not attachments, comments, etc.)
         cql_parts.append("type = page")
 


### PR DESCRIPTION
## Summary
- `wiki search` had no way to filter by label at all.
- Confluence's CQL parser fails silently on hyphenated label values passed unquoted (e.g. `label=aws-services` returns an empty "could not parse cql" error with no indication of what went wrong) — the value must be quoted, same as the existing `space`/`creator` filters already do correctly.
- Adds `--label`, quoting the value consistently with the existing filters.

Found this while building a Claude Code skill that needed to look up Confluence pages by label + title via `zaira wiki search`, and the label filter didn't exist yet.

## Test plan
- [x] Added `test_search_with_label_filter` and `test_search_with_space_and_label_filter` to `tests/test_wiki.py`
- [x] Full suite passes: `uv run pytest tests/` — 1336 passed, 2 skipped
- [x] Verified live against a real Confluence instance: `zaira wiki search "Proton" --space BTA --label aws-services` correctly returns the matching page (previously impossible)